### PR TITLE
Split rewards between creator and marketplace

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -37,3 +37,4 @@ export const ipfsGatewayUri =
     process.env.REACT_APP_IPFS_GATEWAY_URI || 'https://gateway.ipfs.io'
 export const ipfsNodeUri =
     process.env.REACT_APP_IPFS_NODE_URI || 'https://ipfs.infura.io:5001'
+export const marketplaceFeePercentage = Number(process.env.MARKETPLACE_FEE_PERCENTAGE) || 2.5

--- a/client/src/routes/Publish/index.tsx
+++ b/client/src/routes/Publish/index.tsx
@@ -9,7 +9,7 @@ import { User, Market } from '../../context'
 import Step from './Step'
 import Progress from './Progress'
 import ReactGA from 'react-ga'
-import { allowPricing } from '../../config'
+import { allowPricing, gatewayAddress, marketplaceFeePercentage } from '../../config'
 import { steps } from '../../data/form-publish.json'
 import withTracker from '../../hoc/withTracker'
 import { serviceUri } from '../../config'
@@ -303,14 +303,19 @@ class Publish extends Component<{}, PublishState> {
             )
         }
 
+        const rewardsMap = new Map()
+        rewardsMap.set(account[0].getId(), Number(this.state.price) * (1 - marketplaceFeePercentage / 100))
+        rewardsMap.set(gatewayAddress, Number(this.state.price) * marketplaceFeePercentage / 100)
+
         try {
+            console.log(new AssetRewards(rewardsMap))
             // Create NFT
             const asset = await this.context.sdk.nfts.create(
                 newAsset as any,
                 account[0],
                 this.state.nftAmount,
                 this.state.royalty,
-                new AssetRewards(account[0].getId(), Number(this.state.price))
+                new AssetRewards(rewardsMap)
             )
             .next((publishingStep: number) => this.setState({ publishingStep }))
 


### PR DESCRIPTION
## Description

When an NFT is created now, the reward is set to be split between the creator and the marketplace

## Is this PR related with an open issue?

Related to Issue #

Resolves #21 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [X] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()